### PR TITLE
feat: Implement Full CRUD API and DTO Pattern

### DIFF
--- a/documentation-notes.txt
+++ b/documentation-notes.txt
@@ -1,0 +1,41 @@
+17/7/25
+- problem: field injection
+would work, but not best practise, would cause problems later
+in SessionEntryMapper:
+@Autowired
+private WorkPresetMapper workPresetMapper;
+telling Spring to directly "inject" the WorkPresetMapper into this private field
+but that'll be harder to test, the dependencies are not obvious and can't be declared final
+- solution: @RequiredArgsConstructor annotation (automatically generates a constructor for all final fields in the class)
+
+lets test everything again:
+how? postman
+follow the dependency chain: BreakActivity, WorkPreset, SessionEntry
+post & get are working!
+
+3/7/25
+working on: finishing entities
+a bug appeared! 𓆣
+the problem: 
+No serializer found for class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor
+...through reference chain: ...WorkPreset["breakActivity"]->BreakActivity$HibernateProxy["hibernateLazyInitializer"]
+culprit: FetchType.LAZY (jackson cannot serialize hibernates lazy-loading proxy objects)
+solution: DTO's (a pojo that shows data the user)
+stop sending database entities directly to the client, it's for internal use
+process:
+- create dto package & classes
+- service layer: create method to convert database entity into dto
+ -> anotate that with @Transactional(readOnly = true) to ensure lazy-loaded objects can be accessed during conversion
+- adapt controller: call new service method & return list of dto's
+outcome: GET request works again!
+
+FOR LATER
+commit -m:
+feat(presets): Implement versioning for WorkPreset entity
+
+Adds `presetGroupId`, `active`, and `createdAt` fields to the WorkPreset
+entity to support versioning.
+
+This change ensures that SessionEntry records maintain historical
+integrity by linking to an immutable preset version, preventing data
+corruption if a preset is updated in the future.

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,15 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/banvour/pomogatto/controller/BreakActivityController.java
+++ b/src/main/java/com/banvour/pomogatto/controller/BreakActivityController.java
@@ -1,0 +1,46 @@
+package com.banvour.pomogatto.controller;
+
+import com.banvour.pomogatto.dto.BreakActivityDto;
+import com.banvour.pomogatto.dto.CreateOrUpdateBreakActivityDto;
+import com.banvour.pomogatto.service.BreakActivityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/activities")
+@RequiredArgsConstructor
+public class BreakActivityController {
+
+    private final BreakActivityService breakActivityService;
+
+    @GetMapping
+    public ResponseEntity<List<BreakActivityDto>> getAllActivities() {
+        return ResponseEntity.ok(breakActivityService.getAllActivities());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BreakActivityDto> getActivityById(@PathVariable Long id) {
+        return ResponseEntity.ok(breakActivityService.getActivityById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<BreakActivityDto> createActivity(@RequestBody CreateOrUpdateBreakActivityDto dto) {
+        BreakActivityDto createdActivity = breakActivityService.createActivity(dto);
+        return new ResponseEntity<>(createdActivity, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<BreakActivityDto> updateActivity(@PathVariable Long id, @RequestBody CreateOrUpdateBreakActivityDto dto) {
+        return ResponseEntity.ok(breakActivityService.updateActivity(id, dto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteActivity(@PathVariable Long id) {
+        breakActivityService.deleteActivity(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/banvour/pomogatto/controller/SessionEntryController.java
+++ b/src/main/java/com/banvour/pomogatto/controller/SessionEntryController.java
@@ -1,0 +1,46 @@
+package com.banvour.pomogatto.controller;
+
+import com.banvour.pomogatto.dto.CreateOrUpdateSessionEntryDto;
+import com.banvour.pomogatto.dto.SessionEntryDto;
+import com.banvour.pomogatto.service.SessionEntryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/sessions")
+@RequiredArgsConstructor
+public class SessionEntryController {
+
+    private final SessionEntryService sessionEntryService;
+
+    @GetMapping
+    public ResponseEntity<List<SessionEntryDto>> getAllSessionEntries() {
+        return ResponseEntity.ok(sessionEntryService.getAllSessionEntries());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SessionEntryDto> getSessionEntryById(@PathVariable Long id) {
+        return ResponseEntity.ok(sessionEntryService.getSessionEntryById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<SessionEntryDto> createSessionEntry(@RequestBody CreateOrUpdateSessionEntryDto dto) {
+        SessionEntryDto createdSession = sessionEntryService.createSessionEntry(dto);
+        return new ResponseEntity<>(createdSession, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<SessionEntryDto> updateSessionEntry(@PathVariable Long id, @RequestBody CreateOrUpdateSessionEntryDto dto) {
+        return ResponseEntity.ok(sessionEntryService.updateSessionEntry(id, dto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteSessionEntry(@PathVariable Long id) {
+        sessionEntryService.deleteSessionEntry(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/banvour/pomogatto/controller/WorkPresetController.java
+++ b/src/main/java/com/banvour/pomogatto/controller/WorkPresetController.java
@@ -1,0 +1,46 @@
+package com.banvour.pomogatto.controller;
+
+import com.banvour.pomogatto.dto.CreateOrUpdateWorkPresetDto;
+import com.banvour.pomogatto.dto.WorkPresetDto;
+import com.banvour.pomogatto.service.WorkPresetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/presets")
+@RequiredArgsConstructor
+public class WorkPresetController {
+
+    private final WorkPresetService workPresetService;
+
+    @GetMapping
+    public ResponseEntity<List<WorkPresetDto>> getAllPresets() {
+        return ResponseEntity.ok(workPresetService.getAllPresets());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<WorkPresetDto> getPresetById(@PathVariable Long id) {
+        return ResponseEntity.ok(workPresetService.getPresetById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<WorkPresetDto> createPreset(@RequestBody CreateOrUpdateWorkPresetDto dto) {
+        WorkPresetDto createdPreset = workPresetService.createPreset(dto);
+        return new ResponseEntity<>(createdPreset, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<WorkPresetDto> updatePreset(@PathVariable Long id, @RequestBody CreateOrUpdateWorkPresetDto dto) {
+        return ResponseEntity.ok(workPresetService.updatePreset(id, dto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePreset(@PathVariable Long id) {
+        workPresetService.deletePreset(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/banvour/pomogatto/dto/BreakActivityDto.java
+++ b/src/main/java/com/banvour/pomogatto/dto/BreakActivityDto.java
@@ -1,0 +1,19 @@
+package com.banvour.pomogatto.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ *<h6>view model of BreakActivity entity</h6>
+ */
+
+@Getter
+@Setter
+public class BreakActivityDto {
+    private Long id;
+    private String name;
+    private String description;
+    private String alarmSound;
+    private String imageUrl;
+    private boolean hasCounter;
+}

--- a/src/main/java/com/banvour/pomogatto/dto/CreateOrUpdateBreakActivityDto.java
+++ b/src/main/java/com/banvour/pomogatto/dto/CreateOrUpdateBreakActivityDto.java
@@ -1,0 +1,18 @@
+package com.banvour.pomogatto.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * <h6>input model for BreakActivityDto (no id)</h6>
+ */
+
+@Getter
+@Setter
+public class CreateOrUpdateBreakActivityDto {
+    private String name;
+    private String description;
+    private String alarmSound;
+    private String imageUrl;
+    private boolean hasCounter;
+}

--- a/src/main/java/com/banvour/pomogatto/dto/CreateOrUpdateSessionEntryDto.java
+++ b/src/main/java/com/banvour/pomogatto/dto/CreateOrUpdateSessionEntryDto.java
@@ -1,0 +1,16 @@
+package com.banvour.pomogatto.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class CreateOrUpdateSessionEntryDto {
+    private LocalDateTime startTime;
+    private int workDuration;
+    private int breakDuration;
+    private int breakCounter;
+    private String notes;
+    private Long workPresetId;
+}

--- a/src/main/java/com/banvour/pomogatto/dto/CreateOrUpdateWorkPresetDto.java
+++ b/src/main/java/com/banvour/pomogatto/dto/CreateOrUpdateWorkPresetDto.java
@@ -1,0 +1,20 @@
+package com.banvour.pomogatto.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * <h6>input model for WorkPresetDto (no id)</h6>
+ */
+@Getter
+@Setter
+public class CreateOrUpdateWorkPresetDto {
+    private String name;
+    private String description;
+    private int workDuration;
+    private int breakDuration;
+    private int longBreakDuration;
+    private String alarmSound;
+    private String imageUrl;
+    private Long breakActivityId;
+}

--- a/src/main/java/com/banvour/pomogatto/dto/SessionEntryDto.java
+++ b/src/main/java/com/banvour/pomogatto/dto/SessionEntryDto.java
@@ -1,0 +1,22 @@
+package com.banvour.pomogatto.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ *<h6>view model of SessionEntry entity</h6>
+ */
+
+@Getter
+@Setter
+public class SessionEntryDto {
+    private Long id;
+    private LocalDateTime startTime;
+    private int workDuration;
+    private int breakDuration;
+    private int breakCounter;
+    private String notes;
+    private WorkPresetDto workPreset;
+}

--- a/src/main/java/com/banvour/pomogatto/dto/WorkPresetDto.java
+++ b/src/main/java/com/banvour/pomogatto/dto/WorkPresetDto.java
@@ -1,0 +1,22 @@
+package com.banvour.pomogatto.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ *<h6>view model of WorkPreset entity</h6>
+ */
+
+@Getter
+@Setter
+public class WorkPresetDto {
+    private Long id;
+    private String name;
+    private String description;
+    private int workDuration;
+    private int breakDuration;
+    private int longBreakDuration;
+    private String alarmSound;
+    private String imageUrl;
+    private BreakActivityDto breakActivity;
+}

--- a/src/main/java/com/banvour/pomogatto/entity/BreakActivity.java
+++ b/src/main/java/com/banvour/pomogatto/entity/BreakActivity.java
@@ -12,7 +12,6 @@ public class BreakActivity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @Column(nullable = false)
     private String name;
     private String description;

--- a/src/main/java/com/banvour/pomogatto/entity/BreakActivity.java
+++ b/src/main/java/com/banvour/pomogatto/entity/BreakActivity.java
@@ -1,0 +1,22 @@
+package com.banvour.pomogatto.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class BreakActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+    private String description;
+    private String alarmSound;
+    private String imageUrl;
+    private boolean hasCounter;
+}

--- a/src/main/java/com/banvour/pomogatto/entity/SessionEntry.java
+++ b/src/main/java/com/banvour/pomogatto/entity/SessionEntry.java
@@ -1,0 +1,32 @@
+package com.banvour.pomogatto.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+public class SessionEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private LocalDateTime startTime;
+    private int workDuration;
+    private int breakDuration;
+    private int breakCounter;
+    @Column(columnDefinition = "TEXT") // Use TEXT for potentially long notes
+    private String notes;
+
+    // --- Relationships ---
+    @ManyToOne
+    @JoinColumn(name = "preset_id") // Creates the 'presetId' foreign key
+    private WorkPreset workPreset;
+
+    @ManyToOne
+    @JoinColumn(name = "activity_id") // Creates the 'activityId' foreign key
+    private BreakActivity breakActivity;
+}

--- a/src/main/java/com/banvour/pomogatto/entity/SessionEntry.java
+++ b/src/main/java/com/banvour/pomogatto/entity/SessionEntry.java
@@ -18,15 +18,9 @@ public class SessionEntry {
     private int workDuration;
     private int breakDuration;
     private int breakCounter;
-    @Column(columnDefinition = "TEXT") // Use TEXT for potentially long notes
+    @Column(columnDefinition = "TEXT")
     private String notes;
-
-    // --- Relationships ---
     @ManyToOne
-    @JoinColumn(name = "preset_id") // Creates the 'presetId' foreign key
+    @JoinColumn(name = "preset_id")
     private WorkPreset workPreset;
-
-    @ManyToOne
-    @JoinColumn(name = "activity_id") // Creates the 'activityId' foreign key
-    private BreakActivity breakActivity;
 }

--- a/src/main/java/com/banvour/pomogatto/entity/WorkPreset.java
+++ b/src/main/java/com/banvour/pomogatto/entity/WorkPreset.java
@@ -1,0 +1,31 @@
+package com.banvour.pomogatto.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class WorkPreset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+    private String description;
+    private int workDuration;
+    private int breakDuration;
+    private int longBreakDuration;
+    private String alarmSound;
+    private String imageUrl;
+
+    // --- This is the Relationship ---
+    // @ManyToOne: This annotation tells JPA that many "WorkPreset" entries can be related to one "BreakActivity".
+    @ManyToOne
+    // @JoinColumn: This specifies the foreign key column in the database table.
+    // This will create a column named "break_activity_id" in the WorkPreset table,
+    @JoinColumn(name = "break_activity_id")
+    private BreakActivity breakActivity;
+}

--- a/src/main/java/com/banvour/pomogatto/entity/WorkPreset.java
+++ b/src/main/java/com/banvour/pomogatto/entity/WorkPreset.java
@@ -20,12 +20,7 @@ public class WorkPreset {
     private int longBreakDuration;
     private String alarmSound;
     private String imageUrl;
-
-    // --- This is the Relationship ---
-    // @ManyToOne: This annotation tells JPA that many "WorkPreset" entries can be related to one "BreakActivity".
-    @ManyToOne
-    // @JoinColumn: This specifies the foreign key column in the database table.
-    // This will create a column named "break_activity_id" in the WorkPreset table,
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "break_activity_id")
     private BreakActivity breakActivity;
 }

--- a/src/main/java/com/banvour/pomogatto/mapper/BreakActivityMapper.java
+++ b/src/main/java/com/banvour/pomogatto/mapper/BreakActivityMapper.java
@@ -1,0 +1,24 @@
+package com.banvour.pomogatto.mapper;
+
+import com.banvour.pomogatto.dto.BreakActivityDto;
+import com.banvour.pomogatto.entity.BreakActivity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BreakActivityMapper {
+
+    public BreakActivityDto toDto(BreakActivity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        BreakActivityDto dto = new BreakActivityDto();
+        dto.setId(entity.getId());
+        dto.setName(entity.getName());
+        dto.setDescription(entity.getDescription());
+        dto.setAlarmSound(entity.getAlarmSound());
+        dto.setImageUrl(entity.getImageUrl());
+
+        return dto;
+    }
+}

--- a/src/main/java/com/banvour/pomogatto/mapper/SessionEntryMapper.java
+++ b/src/main/java/com/banvour/pomogatto/mapper/SessionEntryMapper.java
@@ -1,0 +1,30 @@
+package com.banvour.pomogatto.mapper;
+
+import com.banvour.pomogatto.dto.SessionEntryDto;
+import com.banvour.pomogatto.entity.SessionEntry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SessionEntryMapper {
+
+    private final WorkPresetMapper workPresetMapper;
+
+    public SessionEntryDto toDto(SessionEntry entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        SessionEntryDto dto = new SessionEntryDto();
+        dto.setId(entity.getId());
+        dto.setStartTime(entity.getStartTime());
+        dto.setWorkDuration(entity.getWorkDuration());
+        dto.setBreakDuration(entity.getBreakDuration());
+        dto.setBreakCounter(entity.getBreakCounter());
+        dto.setNotes(entity.getNotes());
+        dto.setWorkPreset(workPresetMapper.toDto(entity.getWorkPreset()));
+
+        return dto;
+    }
+}

--- a/src/main/java/com/banvour/pomogatto/mapper/WorkPresetMapper.java
+++ b/src/main/java/com/banvour/pomogatto/mapper/WorkPresetMapper.java
@@ -1,0 +1,33 @@
+package com.banvour.pomogatto.mapper;
+
+import com.banvour.pomogatto.dto.WorkPresetDto;
+import com.banvour.pomogatto.entity.WorkPreset;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WorkPresetMapper {
+
+    private final BreakActivityMapper breakActivityMapper;
+
+    public WorkPresetDto toDto(WorkPreset entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        WorkPresetDto dto = new WorkPresetDto();
+        dto.setId(entity.getId());
+        dto.setName(entity.getName());
+        dto.setDescription(entity.getDescription());
+        dto.setWorkDuration(entity.getWorkDuration());
+        dto.setBreakDuration(entity.getBreakDuration());
+        dto.setLongBreakDuration(entity.getLongBreakDuration());
+        dto.setAlarmSound(entity.getAlarmSound());
+        dto.setImageUrl(entity.getImageUrl());
+
+        dto.setBreakActivity(breakActivityMapper.toDto(entity.getBreakActivity()));
+
+        return dto;
+    }
+}

--- a/src/main/java/com/banvour/pomogatto/repository/BreakActivityRepository.java
+++ b/src/main/java/com/banvour/pomogatto/repository/BreakActivityRepository.java
@@ -1,0 +1,9 @@
+package com.banvour.pomogatto.repository;
+
+import com.banvour.pomogatto.entity.BreakActivity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BreakActivityRepository extends JpaRepository<BreakActivity, Long> {
+}

--- a/src/main/java/com/banvour/pomogatto/repository/SessionEntryRepository.java
+++ b/src/main/java/com/banvour/pomogatto/repository/SessionEntryRepository.java
@@ -1,0 +1,9 @@
+package com.banvour.pomogatto.repository;
+
+import com.banvour.pomogatto.entity.SessionEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SessionEntryRepository extends JpaRepository<SessionEntry, Long> {
+}

--- a/src/main/java/com/banvour/pomogatto/repository/WorkPresetRepository.java
+++ b/src/main/java/com/banvour/pomogatto/repository/WorkPresetRepository.java
@@ -1,0 +1,12 @@
+package com.banvour.pomogatto.repository;
+
+import com.banvour.pomogatto.entity.WorkPreset;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * <h3>implements jpa methods like save(), findById() etc. automatically</h2>
+ */
+@Repository
+public interface WorkPresetRepository extends JpaRepository<WorkPreset, Long> {
+}

--- a/src/main/java/com/banvour/pomogatto/service/BreakActivityService.java
+++ b/src/main/java/com/banvour/pomogatto/service/BreakActivityService.java
@@ -1,0 +1,70 @@
+package com.banvour.pomogatto.service;
+
+import com.banvour.pomogatto.dto.BreakActivityDto;
+import com.banvour.pomogatto.dto.CreateOrUpdateBreakActivityDto;
+import com.banvour.pomogatto.entity.BreakActivity;
+import com.banvour.pomogatto.mapper.BreakActivityMapper;
+import com.banvour.pomogatto.repository.BreakActivityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BreakActivityService {
+
+    private final BreakActivityRepository breakActivityRepository;
+    private final BreakActivityMapper breakActivityMapper;
+
+    @Transactional(readOnly = true)
+    public List<BreakActivityDto> getAllActivities() {
+        return breakActivityRepository.findAll()
+                .stream()
+                .map(breakActivityMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public BreakActivityDto getActivityById(Long id) {
+        BreakActivity activity = breakActivityRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Activity not found with id: " + id));
+        return breakActivityMapper.toDto(activity);
+    }
+
+    @Transactional
+    public BreakActivityDto createActivity(CreateOrUpdateBreakActivityDto dto) {
+        BreakActivity activity = new BreakActivity();
+        activity.setName(dto.getName());
+        activity.setDescription(dto.getDescription());
+        activity.setAlarmSound(dto.getAlarmSound());
+        activity.setImageUrl(dto.getImageUrl());
+
+        BreakActivity savedActivity = breakActivityRepository.save(activity);
+        return breakActivityMapper.toDto(savedActivity);
+    }
+
+    @Transactional
+    public BreakActivityDto updateActivity(Long id, CreateOrUpdateBreakActivityDto dto) {
+        BreakActivity activity = breakActivityRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Activity not found with id: " + id));
+
+        activity.setName(dto.getName());
+        activity.setDescription(dto.getDescription());
+        activity.setAlarmSound(dto.getAlarmSound());
+        activity.setImageUrl(dto.getImageUrl());
+
+        BreakActivity updatedActivity = breakActivityRepository.save(activity);
+        return breakActivityMapper.toDto(updatedActivity);
+    }
+
+    @Transactional
+    public void deleteActivity(Long id) {
+        if (!breakActivityRepository.existsById(id)) {
+            throw new RuntimeException("Activity not found with id: " + id);
+        }
+        breakActivityRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/banvour/pomogatto/service/SessionEntryService.java
+++ b/src/main/java/com/banvour/pomogatto/service/SessionEntryService.java
@@ -1,0 +1,77 @@
+package com.banvour.pomogatto.service;
+
+import com.banvour.pomogatto.dto.CreateOrUpdateSessionEntryDto;
+import com.banvour.pomogatto.dto.SessionEntryDto;
+import com.banvour.pomogatto.entity.SessionEntry;
+import com.banvour.pomogatto.entity.WorkPreset;
+import com.banvour.pomogatto.mapper.SessionEntryMapper;
+import com.banvour.pomogatto.repository.SessionEntryRepository;
+import com.banvour.pomogatto.repository.WorkPresetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SessionEntryService {
+
+    private final SessionEntryRepository sessionEntryRepository;
+    private final WorkPresetRepository workPresetRepository;
+    private final SessionEntryMapper sessionEntryMapper;
+
+    @Transactional(readOnly = true)
+    public List<SessionEntryDto> getAllSessionEntries() {
+        return sessionEntryRepository.findAll()
+                .stream()
+                .map(sessionEntryMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public SessionEntryDto getSessionEntryById(Long id) {
+        SessionEntry session = sessionEntryRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("SessionEntry not found with id: " + id));
+        return sessionEntryMapper.toDto(session);
+    }
+
+    @Transactional
+    public SessionEntryDto createSessionEntry(CreateOrUpdateSessionEntryDto dto) {
+        SessionEntry session = new SessionEntry();
+        mapDtoToEntity(dto, session);
+        SessionEntry savedSession = sessionEntryRepository.save(session);
+        return sessionEntryMapper.toDto(savedSession);
+    }
+
+    @Transactional
+    public SessionEntryDto updateSessionEntry(Long id, CreateOrUpdateSessionEntryDto dto) {
+        SessionEntry session = sessionEntryRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("SessionEntry not found with id: " + id));
+
+        mapDtoToEntity(dto, session);
+        SessionEntry updatedSession = sessionEntryRepository.save(session);
+        return sessionEntryMapper.toDto(updatedSession);
+    }
+
+    @Transactional
+    public void deleteSessionEntry(Long id) {
+        if (!sessionEntryRepository.existsById(id)) {
+            throw new RuntimeException("SessionEntry not found with id: " + id);
+        }
+        sessionEntryRepository.deleteById(id);
+    }
+
+    private void mapDtoToEntity(CreateOrUpdateSessionEntryDto dto, SessionEntry entity) {
+        WorkPreset workPreset = workPresetRepository.findById(dto.getWorkPresetId())
+                .orElseThrow(() -> new RuntimeException("WorkPreset not found with id: " + dto.getWorkPresetId()));
+
+        entity.setStartTime(dto.getStartTime());
+        entity.setWorkDuration(dto.getWorkDuration());
+        entity.setBreakDuration(dto.getBreakDuration());
+        entity.setBreakCounter(dto.getBreakCounter());
+        entity.setNotes(dto.getNotes());
+        entity.setWorkPreset(workPreset);
+    }
+}

--- a/src/main/java/com/banvour/pomogatto/service/WorkPresetService.java
+++ b/src/main/java/com/banvour/pomogatto/service/WorkPresetService.java
@@ -1,0 +1,78 @@
+package com.banvour.pomogatto.service;
+
+import com.banvour.pomogatto.dto.CreateOrUpdateWorkPresetDto;
+import com.banvour.pomogatto.dto.WorkPresetDto;
+import com.banvour.pomogatto.entity.BreakActivity;
+import com.banvour.pomogatto.entity.WorkPreset;
+import com.banvour.pomogatto.mapper.WorkPresetMapper;
+import com.banvour.pomogatto.repository.BreakActivityRepository;
+import com.banvour.pomogatto.repository.WorkPresetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class WorkPresetService {
+
+    private final WorkPresetRepository workPresetRepository;
+    private final BreakActivityRepository breakActivityRepository;
+    private final WorkPresetMapper workPresetMapper;
+
+    @Transactional(readOnly = true)
+    public List<WorkPresetDto> getAllPresets() {
+        return workPresetRepository.findAll()
+                .stream()
+                .map(workPresetMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public WorkPresetDto getPresetById(Long id) {
+        WorkPreset workPreset = workPresetRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Preset not found with id: " + id));
+        return workPresetMapper.toDto(workPreset);
+    }
+
+    @Transactional
+    public WorkPresetDto createPreset(CreateOrUpdateWorkPresetDto dto) {
+        WorkPreset workPreset = new WorkPreset();
+        mapDtoToEntity(dto, workPreset);
+        WorkPreset savedPreset = workPresetRepository.save(workPreset);
+        return workPresetMapper.toDto(savedPreset);
+    }
+
+    @Transactional
+    public WorkPresetDto updatePreset(Long id, CreateOrUpdateWorkPresetDto dto) {
+        WorkPreset workPreset = workPresetRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Preset not found with id: " + id));
+        mapDtoToEntity(dto, workPreset);
+        WorkPreset updatedPreset = workPresetRepository.save(workPreset);
+        return workPresetMapper.toDto(updatedPreset);
+    }
+
+    @Transactional
+    public void deletePreset(Long id) {
+        if (!workPresetRepository.existsById(id)) {
+            throw new RuntimeException("Preset not found with id: " + id);
+        }
+        workPresetRepository.deleteById(id);
+    }
+
+    private void mapDtoToEntity(CreateOrUpdateWorkPresetDto dto, WorkPreset entity) {
+        BreakActivity breakActivity = breakActivityRepository.findById(dto.getBreakActivityId())
+                .orElseThrow(() -> new RuntimeException("BreakActivity not found with id: " + dto.getBreakActivityId()));
+
+        entity.setName(dto.getName());
+        entity.setDescription(dto.getDescription());
+        entity.setWorkDuration(dto.getWorkDuration());
+        entity.setBreakDuration(dto.getBreakDuration());
+        entity.setLongBreakDuration(dto.getLongBreakDuration());
+        entity.setAlarmSound(dto.getAlarmSound());
+        entity.setImageUrl(dto.getImageUrl());
+        entity.setBreakActivity(breakActivity);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=pomogatto
+
+# POSTGRESQL DATABASE CONFIGURATION
+spring.datasource.url=jdbc:postgresql://localhost:5432/pomogatto_db
+spring.datasource.username=tuser
+spring.datasource.password=${DB_PASSWORD}
+
+# HIBERNATE/JPA CONFIGURATION
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
This pull request introduces a complete, layered backend architecture for the application.

**Key Changes:**
- Implemented full CRUD (Create, Read, Update, Delete) functionality for `BreakActivity`, `WorkPreset`, and `SessionEntry`.
- Established a clean API using separate DTOs for requests and responses.
- Created a dedicated Mapper layer to handle conversions between Entities and DTOs, solving lazy-loading issues.
- Refactored all services and controllers to use constructor injection.
- Centralized DTO-to-Entity mapping logic into private helper methods within each service.

The application is now fully functional with a stable "Version 1" API, ready for frontend integration or further backend enhancements.