### PR TITLE
feat: Implement versioning for Work Presets to ensure historical accuracy

### DIFF
--- a/src/main/java/com/banvour/pomogatto/entity/WorkPreset.java
+++ b/src/main/java/com/banvour/pomogatto/entity/WorkPreset.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Setter
@@ -12,6 +14,14 @@ public class WorkPreset {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+//    @Column(nullable = false)
+    private Long presetGroupId;
+    @Column(nullable = false)
+    private boolean active;
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
     @Column(nullable = false)
     private String name;
     private String description;

--- a/src/main/java/com/banvour/pomogatto/repository/WorkPresetRepository.java
+++ b/src/main/java/com/banvour/pomogatto/repository/WorkPresetRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
  */
 @Repository
 public interface WorkPresetRepository extends JpaRepository<WorkPreset, Long> {
-    List<WorkPreset> findAllByOrderByIdAsc();
+    List<WorkPreset> findByActiveOrderByPresetGroupIdAscIdAsc(boolean active);
 }

--- a/src/main/java/com/banvour/pomogatto/service/WorkPresetService.java
+++ b/src/main/java/com/banvour/pomogatto/service/WorkPresetService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,7 +25,7 @@ public class WorkPresetService {
 
     @Transactional(readOnly = true)
     public List<WorkPresetDto> getAllPresets() {
-        return workPresetRepository.findAllByOrderByIdAsc()
+        return workPresetRepository.findByActiveOrderByPresetGroupIdAscIdAsc(true)
                 .stream()
                 .map(workPresetMapper::toDto)
                 .collect(Collectors.toList());
@@ -40,18 +41,41 @@ public class WorkPresetService {
     @Transactional
     public WorkPresetDto createPreset(CreateOrUpdateWorkPresetDto dto) {
         WorkPreset workPreset = new WorkPreset();
+        workPreset.setActive(true);
+        workPreset.setCreatedAt(LocalDateTime.now());
         mapDtoToEntity(dto, workPreset);
-        WorkPreset savedPreset = workPresetRepository.save(workPreset);
-        return workPresetMapper.toDto(savedPreset);
+        WorkPreset initialSave = workPresetRepository.save(workPreset);
+        initialSave.setPresetGroupId(initialSave.getId());
+        WorkPreset finalSave = workPresetRepository.save(initialSave);
+        return workPresetMapper.toDto(finalSave);
     }
 
     @Transactional
-    public WorkPresetDto updatePreset(Long id, CreateOrUpdateWorkPresetDto dto) {
-        WorkPreset workPreset = workPresetRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Preset not found with id: " + id));
-        mapDtoToEntity(dto, workPreset);
-        WorkPreset updatedPreset = workPresetRepository.save(workPreset);
-        return workPresetMapper.toDto(updatedPreset);
+    public WorkPresetDto updatePreset(Long idOfOldVersion, CreateOrUpdateWorkPresetDto dto) {
+        // 1. Find the old version that is being edited.
+        WorkPreset oldVersion = workPresetRepository.findById(idOfOldVersion)
+                .orElseThrow(() -> new RuntimeException("Preset version to update not found with id: " + idOfOldVersion));
+
+        // 2. Deactivate the old version.
+        oldVersion.setActive(false);
+        workPresetRepository.save(oldVersion);
+
+        // 3. Create a new WorkPreset instance for the new version.
+        WorkPreset newVersion = new WorkPreset();
+
+        newVersion.setActive(true);
+        newVersion.setCreatedAt(LocalDateTime.now());
+
+        // 4. Map the new data onto this new instance.
+        mapDtoToEntity(dto, newVersion);
+
+        // 5. Crucially, link the new version to the same group as the old one.
+        newVersion.setPresetGroupId(oldVersion.getPresetGroupId());
+
+        // 6. Save the new version. It will automatically be active and get a new ID.
+        WorkPreset savedNewVersion = workPresetRepository.save(newVersion);
+
+        return workPresetMapper.toDto(savedNewVersion);
     }
 
     @Transactional

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -8,7 +8,6 @@
 </head>
 <body>
 
-<!-- === HOME SCREEN VIEW (Visible by default) === -->
 <div id="home-screen" class="app-window home-view">
     <div class="title-bar">
         <div class="title-icon">


### PR DESCRIPTION
This refactors the WorkPreset update logic to treat presets as immutable, solving the problem of historical data being corrupted when a preset is edited.

Key changes:
- Update operations now deactivate the old preset version and create a new one.
- Added , , and  fields to the  entity to manage the version chain.
- Implemented a 'save-twice' pattern for new presets to establish the initial .
- The  endpoint now correctly fetches only active presets and sorts them by  to maintain a stable list order for the UI.